### PR TITLE
replace user_identity_field with user_id_claim in jwt

### DIFF
--- a/config/packages/lexik_jwt_authentication.yaml
+++ b/config/packages/lexik_jwt_authentication.yaml
@@ -2,5 +2,5 @@ lexik_jwt_authentication:
     secret_key: '%env(resolve:JWT_SECRET_KEY)%'
     public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
     pass_phrase: '%env(JWT_PASSPHRASE)%'
-    user_identity_field: email
+    user_id_claim: email
     token_ttl: 28800 # in seconds, default is 3600


### PR DESCRIPTION
in lexik_jwt_authentication.yaml replaced user_identity_field with user_id_claim
TO FIX : 
User Deprecated: Since lexik/jwt-authentication-bundle 2.16: The "lexik_jwt_authentication.user_identity_field" configuration key is deprecated since version 2.16, use "lexik_jwt_authentication.user_id_claim" or implement "Symfony\Component\Security\Core\User\UserInterface::getUserIdentifier()" instead. {"exception":"[object] (ErrorException(code: 0):